### PR TITLE
Add option to manually select CSV headers

### DIFF
--- a/src/pages/NewIndexPage.vue
+++ b/src/pages/NewIndexPage.vue
@@ -399,7 +399,8 @@ export default defineComponent({
         {label: 'Bar', value: 'bar'},
         {label: 'Scatter', value: 'scatter'}
       ],
-      selected_chart_type: 'bar'
+      selected_chart_type: 'bar',
+      hasHeaders: true // Added checkbox state
     }
   },
   components: {
@@ -531,7 +532,7 @@ export default defineComponent({
           self.$q.loading.show();
           await self.$conn.query(`CREATE TABLE ${name} AS
           SELECT *
-          FROM read_csv_auto('sample_table.csv');`);
+          FROM read_csv_auto('sample_table.csv', HEADER=${self.hasHeaders});`);
           self.$refs.uploaderref.reset();
           self.selectTable(name);
           const stmt1 = await self.$conn.prepare(`SELECT CAST(COUNT(*) AS INT)


### PR DESCRIPTION
Related to #4

Add a checkbox to manually specify if the CSV file has headers.

* Add `hasHeaders` state to the data object to store the checkbox value.
* Update the `files` method to include the `HEADER` option when creating the table based on the checkbox value.
* Modify the file upload logic to use the `read_csv_auto` function with the `HEADER` option based on the checkbox value.

